### PR TITLE
ajout module contenant des composants imbriqués

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,17 +2,17 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
 import { AppRoutingModule } from './app-routing.module';
+import { FooModule } from './foo/foo.module';
 import { AppComponent } from './app.component';
-import { FooComponent } from './foo/foo.component';
 
 @NgModule({
   declarations: [
-    AppComponent,
-    FooComponent
+    AppComponent
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    FooModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/foo/bar/bar.component.html
+++ b/src/app/foo/bar/bar.component.html
@@ -1,0 +1,3 @@
+<p>
+  bar works!
+</p>

--- a/src/app/foo/bar/bar.component.spec.ts
+++ b/src/app/foo/bar/bar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BarComponent } from './bar.component';
+
+describe('BarComponent', () => {
+  let component: BarComponent;
+  let fixture: ComponentFixture<BarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ BarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/foo/bar/bar.component.ts
+++ b/src/app/foo/bar/bar.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-bar',
+  templateUrl: './bar.component.html',
+  styleUrls: ['./bar.component.sass']
+})
+export class BarComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/foo/foo.component.html
+++ b/src/app/foo/foo.component.html
@@ -1,1 +1,2 @@
 <h1>hello</h1>
+<app-bar></app-bar>

--- a/src/app/foo/foo.module.ts
+++ b/src/app/foo/foo.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FooComponent } from './foo.component';
+import { BarComponent } from './bar/bar.component';
+
+@NgModule({
+  declarations: [
+    FooComponent,
+    BarComponent
+  ],
+  exports: [
+    FooComponent
+  ],
+  imports: [
+    CommonModule
+  ]
+})
+export class FooModule { }


### PR DESCRIPTION
- ajout du module **foo** via `ng g module foo`
- déplacement du composant foo du module **app** au module **foo**
- ajout du composant bar dans le module **foo** `ng g component foo/bar`, et insertion de ce dernier dans le composant foo

⚠️ afin que le composant foo soit toujours accessible dans le module principale penser à le rendre accessible en l'exportant de son module : 
`exports: [
    FooComponent
  ],`